### PR TITLE
Interface for distributions3 infrastructure, enabling topmodels infrastructure

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Authors@R: c(person("Mikis", "Stasinopoulos", role = c("aut", "cph"),
 Description: The primary purpose of this package is to facilitate the creation of
   advanced infrastructures designed to enhance the GAMLSS modeling framework.
 Depends: R (>= 4.1.0), gamlss.dist, gamlss.data, Formula, mgcv
-Suggests: gamlss, colorspace, knitr, scoringRules, partykit, nnet, lattice, rpart
+Suggests: gamlss, colorspace, knitr, scoringRules, partykit, nnet, lattice, rpart, distributions3
 License: GPL-2 | GPL-3
 LazyLoad: yes
 RoxygenNote: 7.1.1

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -62,5 +62,7 @@ S3method(BIC, gamlss2)
 S3method(c, gamlss2)
 S3method(quantile, gamlss2)
 
+S3method(distributions3::prodist, gamlss2)
+
 useDynLib(gamlss2, .registration = TRUE)
 

--- a/R/prodist.R
+++ b/R/prodist.R
@@ -1,0 +1,17 @@
+## S3 method for extracting fitted/predicted distributions3 objects
+## associated methods are in gamlss.dist (as well as distributions3, topmodels, etc.)
+prodist.gamlss2 <- function(object, ...) {
+  ## extract fitted parameters
+  d <- predict(object, ..., type = "parameter", drop = FALSE)
+
+  ## set class to general GAMLSS distribution (distributions3 object)
+  class(d) <- c("GAMLSS", "distribution")
+
+  ## include family information
+  ## (FIXME: For now just use the character label, but moving forward maybe
+  ## the functions in object$family should be used)
+  attr(d, "family") <- object$family$family
+
+  ## return distributions3 object
+  return(d)
+}

--- a/man/predict.gamlss2.Rd
+++ b/man/predict.gamlss2.Rd
@@ -1,0 +1,87 @@
+\name{predict.gamlss2}
+
+\alias{predict.gamlss2}
+
+\title{Extracting Fitted or Predicted Parameters or Terms from gamlss2 Models}
+
+\description{
+Methods for \pkg{gamlss2} model objects for extracting fitted (in-sample) or
+predicted (out-of-sample) parameters, terms, etc.
+}
+
+\usage{
+\method{predict}{gamlss2}(object, model = NULL, newdata = NULL,
+  type = c("link", "parameter", "response", "terms"), terms = NULL,
+  se.fit = FALSE, drop = TRUE, ...)
+}
+\arguments{
+  \item{object}{model object of class \code{\link{gamlss2}}.}
+  \item{model}{character. Which model part(s) should be predicted?
+    Can be one or more of \code{"mu"}, \code{"sigma"}, etc. By default
+    all model parts are included.}
+  \item{newdata}{data.frame. Optionally, a new data frame in which to
+    look for variables with which to predict. If omitted, the original
+    observations are used.}
+  \item{type}{character. Which type of prediction should be computed?
+    Can be the full additive predictor(s) (\code{"link"}, before applying the link function(s)),
+    the corresponding parameter (\code{"parameter"}, after applying the link function(s)),
+    the individual terms of the additive predictor(s) (\code{"terms"}),
+    or the corresponding mean of the response distribution (\code{"response"}).}
+  \item{terms}{character. Which of the terms in the additive predictor(s)
+    should be included? By default all terms are included.}
+  \item{se.fit}{logical. Should standard errors for the predictions be included?
+    \emph{(not implemented yet)}.}
+  \item{drop}{logical. Should the predictions be simplified to a vector
+    if possible (\code{TRUE}) or always returned as a data.frame (\code{FALSE})?}
+  \item{...}{currently only used for catching \code{what} as an alias for \code{model}.}
+}
+
+\details{
+Predictions for \code{\link{gamlss2}} model objects are obtained in the following steps:
+First, the original data is extracted or some \code{newdata} is set up.
+Second, all of the terms in the additive predictors of all model parameters
+(\code{"mu"}, \code{"sigma"}, ...) are computed.
+Third, the full additive predictor(s) are obtained by adding up all individual terms.
+Fourth, the parameter(s) are obtained from the additive predictor(s) by applying the inverse
+link function(s).
+In a final step, the mean of the associated probability distribution can be computed.
+
+See also \code{\link{prodist.gamlss2}} for setting up a full \pkg{distributions3} object
+from which moments, probabilities, quantiles, or random numbers can be obtained.
+}
+
+\value{
+If \code{drop = FALSE} a data.frame. If \code{drop = TRUE} (the default),
+the data.frame might be simplified to a numeric vector, if possible.
+}
+
+\seealso{
+\code{\link[stats]{predict}}, \code{\link{prodist.gamlss2}}
+}
+
+\examples{
+## fit heteroscedastic normal GAMLSS model
+## stopping distance (ft) explained by speed (mph)
+data("cars", package = "datasets")
+m <- gamlss2(dist ~ s(speed) | s(speed), data = cars, family = NO)
+
+## new data for predictions
+nd <- data.frame(speed = c(10, 20, 30))
+
+## default: additive predictors (on link scale) for all model parameters
+predict(m, newdata = nd)
+
+## mean of the response distribution
+predict(m, newdata = nd, type = "response")
+
+## model parameter(s)
+predict(m, newdata = nd, type = "parameter")
+predict(m, newdata = nd, type = "parameter", model = "sigma")
+predict(m, newdata = nd, type = "parameter", model = "sigma", drop = FALSE)
+
+## individual terms in additive predictor(s)
+predict(m, newdata = nd, type = "terms", model = "sigma")
+predict(m, newdata = nd, type = "terms", model = "sigma", terms = "s(speed)")
+}
+
+\keyword{regression}

--- a/man/prodist.gamlss2.Rd
+++ b/man/prodist.gamlss2.Rd
@@ -1,0 +1,106 @@
+\name{prodist.gamlss2}
+
+\alias{prodist.gamlss2}
+
+\title{Extracting Fitted or Predicted Probability Distributions from gamlss2 Models}
+
+\description{
+Methods for \pkg{gamlss2} model objects for extracting fitted (in-sample) or
+predicted (out-of-sample) probability distributions as \pkg{distributions3}
+objects.
+}
+
+\usage{
+\method{prodist}{gamlss2}(object, ...)
+}
+\arguments{
+  \item{object}{A model object of class \code{\link{gamlss2}}.}
+  \item{...}{Arguments passed on to \code{\link{predict.gamlss2}}, e.g., \code{newdata}.}
+}
+
+\details{
+To facilitate making probabilistic forecasts based on \code{\link{gamlss2}}
+model objects, the \code{\link[distributions3]{prodist}} method extracts fitted
+or predicted probability \code{distribution} objects. Internally, the
+\code{\link{predict.gamlss2}} method is used first to obtain the distribution
+parameters (\code{mu}, \code{sigma}, \code{tau}, \code{nu}, or a subset thereof).
+Subsequently, the corresponding \code{distribution} object is set up using the
+\code{\link[gamlss.dist]{GAMLSS}} class from the \pkg{gamlss.dist} package,
+enabling the workflow provided by the \pkg{distributions3} package (see Zeileis
+et al. 2022).
+
+Note that these probability distributions only reflect the random variation in
+the dependent variable based on the model employed (and its associated
+distributional assumption for the dependent variable). This does not capture the
+uncertainty in the parameter estimates.
+}
+
+\value{
+An object of class \code{GAMLSS} inheriting from \code{distribution}.
+}
+
+\references{
+Zeileis A, Lang MN, Hayes A (2022).
+\dQuote{distributions3: From Basic Probability to Probabilistic Regression.}
+Presented at \emph{useR! 2022 - The R User Conference}.
+Slides, video, vignette, code at \url{https://www.zeileis.org/news/user2022/}.
+}
+
+\seealso{
+\code{\link[gamlss.dist]{GAMLSS}}, \code{\link{predict.gamlss2}}
+}
+
+\examples{
+\dontshow{ if(!requireNamespace("distributions3")) {
+  if(interactive() || is.na(Sys.getenv("_R_CHECK_PACKAGE_NAME_", NA))) {
+    stop("not all packages required for the example are installed")
+  } else q() }
+}
+## packages, code, and data
+library("distributions3")
+data("cars", package = "datasets")
+
+## fit heteroscedastic normal GAMLSS model
+## stopping distance (ft) explained by speed (mph)
+m <- gamlss2(dist ~ s(speed) | s(speed), data = cars, family = NO)
+
+## obtain predicted distributions for three levels of speed
+d <- prodist(m, newdata = data.frame(speed = c(10, 20, 30)))
+print(d)
+
+## obtain quantiles (works the same for any distribution object 'd' !)
+quantile(d, 0.5)
+quantile(d, c(0.05, 0.5, 0.95), elementwise = FALSE)
+quantile(d, c(0.05, 0.5, 0.95), elementwise = TRUE)
+
+## visualization
+plot(dist ~ speed, data = cars)
+nd <- data.frame(speed = 0:240/4)
+nd$dist <- prodist(m, newdata = nd)
+nd$fit <- quantile(nd$dist, c(0.05, 0.5, 0.95))
+matplot(nd$speed, nd$fit, type = "l", lty = 1, col = "slategray", add = TRUE)
+
+## moments
+mean(d)
+variance(d)
+
+## simulate random numbers
+random(d, 5)
+
+## density and distribution
+pdf(d, 50 * -2:2)
+cdf(d, 50 * -2:2)
+
+## Poisson example
+data("FIFA2018", package = "distributions3")
+m2 <- gamlss2(goals ~ s(difference), data = FIFA2018, family = PO)
+d2 <- prodist(m2, newdata = data.frame(difference = 0))
+print(d2)
+quantile(d2, c(0.05, 0.5, 0.95))
+
+## note that log_pdf() can replicate logLik() value
+sum(log_pdf(prodist(m2), FIFA2018$goals))
+logLik(m2)
+}
+
+\keyword{distribution}


### PR DESCRIPTION
Niki @freezenik, in this PR I have done the following:

- Added a `prodist()` method for extracting/predicting probability distribution objects in the framework of the `distributions3` package. The idea of the package is that you can work with (vectors of) distributions in an object-oriented way, e.g., for computing moments, probabilities, quantiles, or random numbers etc.
- The accompanying manual page shows how to call `prodist()` directly and then work with the resulting `distributions3` objects "by hand". See also <https://www.zeileis.org/news/user2022/> for some more background and motivation.
- The more interesting part, however, is that it "unlocks" all of the infrastructure in the `topmodels` package, providing probabilistic forecasts, residuals, scoring rules, goodness-of-fit graphics, etc.
- Because the `prodist.gamlss2` documentation needed to link to the documentation of `predict.gamlss2` I have also added a manual page for this.
- Finally, a `Suggests` dependency is added for `distributions3` and the `prodist()` method is registered in the `NAMESPACE`. No dependency is needed for `topmodels` at the moment, but maybe a vignette could be useful in the future.