### PR TITLE
newresponse() method not needed anymore in gamlss2

### DIFF
--- a/R/prodist.R
+++ b/R/prodist.R
@@ -15,15 +15,3 @@ prodist.gamlss2 <- function(object, ...) {
   ## return distributions3 object
   return(d)
 }
-
-## newresponse() method for topmodels.
-newresponse.gamlss2 <- function(object, newdata, ...)
-{
-  y <- if(missing(newdata) || is.null(newdata)) {
-    model.response(model.frame(object, keepresponse = TRUE))
-  } else {
-    model.response(model.frame(object, keepresponse = TRUE, data = newdata))
-  }
-  return(y)
-}
-


### PR DESCRIPTION
Niki, the `newresponse()` method in `gamlss2` can be dropped because I have improved the default method in `topmodels`. Hence this PR simply drops it.